### PR TITLE
Update SDK constraint in pubspec.yaml

### DIFF
--- a/featurehub-sse-client/pubspec.yaml
+++ b/featurehub-sse-client/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.3.3
 repository: https://github.com/featurehub-io/featurehub-flutter-sdk/tree/main/featurehub-sse-client
 homepage: https://www.featurehub.io
 environment:
-  sdk: '>=2.12.0 <3.9.9'
+  sdk: '>=2.12.0 <4.0.0'
 
 dependencies:
   collection: ^1.15.0


### PR DESCRIPTION
At the time of this PR, Dart SDK version is 3.10.x and apps using that SDK fail to build. By updating SDK constant to <4.0.0, nothing actually changes and it allows the library to be built with the latest Flutter versions.